### PR TITLE
Make HOC & Decorator work with the new Mixin class

### DIFF
--- a/src/Decorator.js
+++ b/src/Decorator.js
@@ -1,8 +1,8 @@
 var React = global.React || require('react');
 
-import Mixin from './Mixin.js';
+import HOC from './HOC';
 
-export default () => (Component) => Mixin((props) => {
+export default () => (Component) => HOC((props) => {
   return (
     <Component {...props} />
   )

--- a/src/HOC.js
+++ b/src/HOC.js
@@ -15,8 +15,26 @@ export default (Component) => class extends Mixin {
 
   render() {
     const { innerRef } = this.props;
+    const formsyProps = {
+      setValidations: this.setValidations,
+      setValue: this.setValue,
+      getValue: this.getValue,
+      hasValue: this.hasValue,
+      getErrorMessage: this.getErrorMessage,
+      getErrorMessages: this.getErrorMessages,
+      isFormDisabled: this.isFormDisabled,
+      isValid: this.isValid,
+      isPristine: this.isPristine,
+      isFormSubmitted: this.isFormSubmitted,
+      isRequired: this.isRequired,
+      showRequired: this.showRequired,
+      showError: this.showError,
+      isValidValue: this.isValidValue,
+      resetValue: this.resetValue,
+    };
+
     return (
-      <Component ref={innerRef} {...this.props} />
+      <Component ref={innerRef} {...this.props} {...formsyProps}/>
     )
   }
 }


### PR DESCRIPTION
I have tested the changes against a package I maintain ([formsy-semantic-ui-react](https://github.com/zabute/formsy-semantic-ui-react)) that relies on ```Formsy.Decorator```. All tests are passing.