### PR TITLE
add browserify so this module can be used on the web

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,6 @@
     "react",
     "es2015",
     "stage-2"
-  ]
+  ],
+  "plugins": ["transform-class-properties"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+browser.js

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "url": "https://github.com/st-andrew/formsy-react-2.git"
   },
   "main": "lib/main.js",
+  "browser": "browser.js",
   "scripts": {
-    "prepublishOnly": "npm run test && npm run build",
+    "prepublishOnly": "npm run test && npm run build && npm run browser",
     "build": "babel ./src/ -d ./lib/",
+    "browser": "browserify ./src/main.js -o browser.js -t [ babelify --presets [ env react ] --plugins [ transform-class-properties ] ]",
     "test": "babel-node testrunner"
   },
   "author": "Andrew MacCuaig",
@@ -28,9 +30,12 @@
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-eslint": "^7.2.3",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
+    "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.5.0",
+    "babelify": "^8.0.0",
+    "browserify": "^14.5.0",
     "eslint": "^4.0.0",
     "eslint-plugin-react": "^7.0.1",
     "jsdom": "^11.0.0",


### PR DESCRIPTION
@maccuaa Hey there, excited to have found an ES6 aware alternative to the original `react-formsy`.

I added some dev dependencies and made it so that there's a new `browser.js` file that is generated.

Please let me know if there's more I can do to help this land.

Thanks,

Brekk